### PR TITLE
New db options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .directory
 .htaccess
 .vscode
+.idea
 credentials.php

--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ Calorific is developed and tested using Apache2 and MySQL, but other web servers
 2. Put the `calorific` directory in your web server document root (typically `/var/www/html`).
 3. Create `credentials.php` within the same directory as `index.php`, and populate it with the following:
 
-```
+```php
 <?php
 $mysqlHost = "your-sql-hostname";
 $mysqlUser = "your-sql-username";
 $mysqlPassword = "your-sql-password";
-?>
+$mysqlDB = "your-sql-database";
+// uncomment if using mysql < 8 or mariadb < 11.4.5
+// $mysqlCollation = "utf8mb4_general_ci";
 ```
 
 4. Replace the values of the variables to fit your database configuration. Calorific will set up the database structure by itself.

--- a/index.php
+++ b/index.php
@@ -22,6 +22,9 @@
 $mysqlHost = "db";
 $mysqlUser = "php_docker";
 $mysqlPassword = "password123";
+$mysqlDB = "calorific";
+// collation for use when creating tables, use utf8mb4_general_ci for mysql < 8 or mariadb < 11.4.5
+$mysqlCollation = "utf8mb4_0900_ai_ci";
 
 error_reporting(E_ERROR); // Silence the next line so it doesn't cry when running in Docker
 include("./credentials.php");

--- a/php/dbsetup.php
+++ b/php/dbsetup.php
@@ -1,14 +1,19 @@
 <?php
 // Setup DB if it's the first run
-mysqli_query($link, "CREATE DATABASE IF NOT EXISTS calorific");
-mysqli_select_db($link, "calorific");
+mysqli_query($link, "CREATE DATABASE IF NOT EXISTS `$mysqlDB`");
+mysqli_select_db($link, $mysqlDB);
+
+if (!isset($mysqlCollation)) {
+    $mysqlCollation = "utf8mb4_0900_ai_ci";
+}
+
 mysqli_query($link, "
     CREATE TABLE IF NOT EXISTS `meals` (
         `ID` int NOT NULL AUTO_INCREMENT,
         `name` varchar(255) NOT NULL,
         `kcal` int NOT NULL,
         PRIMARY KEY (`ID`)
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;");
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=$mysqlCollation;");
 
 mysqli_query($link, "
     CREATE TABLE IF NOT EXISTS `ingredients` (
@@ -16,8 +21,7 @@ mysqli_query($link, "
         `name` varchar(255) NOT NULL,
         `kcalPer100` int NOT NULL,
         PRIMARY KEY (`ID`)
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;");
-
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=$mysqlCollation;");
 
 mysqli_query($link, "
     CREATE TABLE IF NOT EXISTS `history` (
@@ -26,11 +30,11 @@ mysqli_query($link, "
         `kcal` int NOT NULL,
         `time` datetime NOT NULL,
         PRIMARY KEY (`ID`)
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;");
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=$mysqlCollation;");
 
 mysqli_query($link, "
     CREATE TABLE IF NOT EXISTS `settings` (
         `key` varchar(255) NOT NULL,
         `value` varchar(255) NOT NULL,
         PRIMARY KEY (`key`)
-    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;");
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=$mysqlCollation;");


### PR DESCRIPTION
Hi, me again.

The environment I've installed my instance on uses a specifc db name and is an older version of mariadb that doesn't support newer collations.

So this change is to allow specifying via credentials.php a database name and collation to use, both are optional. Its all backwards compatible as it'll behave as it does at the moment.

Sam
